### PR TITLE
bugfix: fix wrong json file in cartfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ BlinkCard SDK is available via [Carthage](https://github.com/Carthage/Carthage).
 - Add BlinkCard as a dependency to this Cartfile:
 
 ```shell
-binary "https://github.com/BlinkCard/blinkcard-ios/blob/master/blinkcard-ios.json"
+binary  "https://raw.githubusercontent.com/blinkcard/blinkcard-ios/master/blinkcard-ios.json"
 ```
 - Run ```carthage update --use-xcframeworks```.
 - If successful, a Cartfile.resolved file and a Carthage directory will appear in the same directory as your Xcode project.


### PR DESCRIPTION
The content in cartfile, 
`binary "https://github.com/BlinkCard/blinkcard-ios/blob/master/blinkcard-ios.json"` will get  wrong JSON format error when running Carthage command.   It should use raw json file content. 

